### PR TITLE
Add compile-time support for both db implementations: in-memory and LMDB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,27 @@ if(STATIC)
   endif()
 endif()
 
+# default database:
+# should be lmdb for testing, memory for production still
+# set(DATABASE memory)
+set(DATABASE lmdb)
+
+if (DEFINED ENV{DATABASE})
+  set(DATABASE $ENV{DATABASE})
+  message(STATUS "DATABASE set: ${DATABASE}")
+else()
+  message(STATUS "Could not find DATABASE in env (not required unless you want to change database type from default: ${DATABASE})")
+endif()
+if (DATABASE STREQUAL "lmdb")
+  set(BLOCKCHAIN_DB DB_LMDB)
+elseif (DATABASE STREQUAL "memory")
+  set(BLOCKCHAIN_DB DB_MEMORY)
+else()
+  die("Invalid database type: ${DATABASE}")
+endif()
+
+add_definitions("-DBLOCKCHAIN_DB=${BLOCKCHAIN_DB}")
+
 if (UNIX AND NOT APPLE)
   # Note that at the time of this writing the -Wstrict-prototypes flag added below will make this fail
   find_package(Threads)

--- a/src/blockchain_converter/CMakeLists.txt
+++ b/src/blockchain_converter/CMakeLists.txt
@@ -35,6 +35,7 @@ set(blockchain_converter_private_headers)
 bitmonero_private_headers(blockchain_converter
 	  ${blockchain_converter_private_headers})
 
+if (BLOCKCHAIN_DB STREQUAL DB_LMDB)
 bitmonero_add_executable(blockchain_converter
   ${blockchain_converter_sources}
   ${blockchain_converter_private_headers})
@@ -49,3 +50,4 @@ add_dependencies(blockchain_converter
 set_property(TARGET blockchain_converter
 	PROPERTY
 	OUTPUT_NAME "blockchain_converter")
+endif ()

--- a/src/cryptonote_core/blockchain_storage.cpp
+++ b/src/cryptonote_core/blockchain_storage.cpp
@@ -640,7 +640,7 @@ bool blockchain_storage::get_last_n_blocks_sizes(std::vector<size_t>& sz, size_t
   return get_backward_blocks_sizes(m_blocks.size() -1, sz, count);
 }
 //------------------------------------------------------------------
-uint64_t blockchain_storage::get_current_comulative_blocksize_limit() const
+uint64_t blockchain_storage::get_current_cumulative_blocksize_limit() const
 {
   return m_current_block_cumul_sz_limit;
 }

--- a/src/cryptonote_core/blockchain_storage.h
+++ b/src/cryptonote_core/blockchain_storage.h
@@ -131,7 +131,7 @@ namespace cryptonote
     bool check_tx_inputs(const transaction& tx, const crypto::hash& tx_prefix_hash, uint64_t* pmax_used_block_height = NULL) const;
     bool check_tx_inputs(const transaction& tx, uint64_t* pmax_used_block_height = NULL) const;
     bool check_tx_inputs(const transaction& tx, uint64_t& pmax_used_block_height, crypto::hash& max_used_block_id) const;
-    uint64_t get_current_comulative_blocksize_limit() const;
+    uint64_t get_current_cumulative_blocksize_limit() const;
     bool is_storing_blockchain()const{return m_is_blockchain_storing;}
     uint64_t block_difficulty(size_t i) const;
 

--- a/src/cryptonote_core/cryptonote_basic.h
+++ b/src/cryptonote_core/cryptonote_basic.h
@@ -50,6 +50,8 @@
 #include "misc_language.h"
 #include "tx_extra.h"
 
+#define DB_MEMORY 1
+#define DB_LMDB   2
 
 namespace cryptonote
 {

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -51,7 +51,11 @@ namespace cryptonote
   //-----------------------------------------------------------------------------------------------
   core::core(i_cryptonote_protocol* pprotocol):
               m_mempool(m_blockchain_storage),
+#if BLOCKCHAIN_DB == DB_LMDB
               m_blockchain_storage(m_mempool),
+#else
+              m_blockchain_storage(&m_mempool),
+#endif
               m_miner(this),
               m_miner_address(boost::value_initialized<account_public_address>()), 
               m_starter_message_showed(false),
@@ -577,7 +581,11 @@ namespace cryptonote
       m_starter_message_showed = true;
     }
 
+#if BLOCKCHAIN_DB == DB_LMDB
     m_store_blockchain_interval.do_call(boost::bind(&Blockchain::store_blockchain, &m_blockchain_storage));
+#else
+    m_store_blockchain_interval.do_call(boost::bind(&blockchain_storage::store_blockchain, &m_blockchain_storage));
+#endif
     m_miner.on_idle();
     m_mempool.on_idle();
     return true;

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -39,7 +39,11 @@
 #include "cryptonote_protocol/cryptonote_protocol_handler_common.h"
 #include "storages/portable_storage_template_helper.h"
 #include "tx_pool.h"
+#if BLOCKCHAIN_DB == DB_LMDB
 #include "blockchain.h"
+#else
+#include "blockchain_storage.h"
+#endif
 #include "miner.h"
 #include "connection_context.h"
 #include "cryptonote_core/cryptonote_stat_info.h"
@@ -112,7 +116,11 @@ namespace cryptonote
      bool get_random_outs_for_amounts(const COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::request& req, COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::response& res);
      void pause_mine();
      void resume_mine();
+#if BLOCKCHAIN_DB == DB_LMDB
      Blockchain& get_blockchain_storage(){return m_blockchain_storage;}
+#else
+     blockchain_storage& get_blockchain_storage(){return m_blockchain_storage;}
+#endif
      //debug functions
      void print_blockchain(uint64_t start_index, uint64_t end_index);
      void print_blockchain_index();
@@ -149,7 +157,11 @@ namespace cryptonote
 
 
      tx_memory_pool m_mempool;
+#if BLOCKCHAIN_DB == DB_LMDB
      Blockchain m_blockchain_storage;
+#else
+     blockchain_storage m_blockchain_storage;
+#endif
      i_cryptonote_protocol* m_pprotocol;
      epee::critical_section m_incoming_tx_lock;
      //m_miner and m_miner_addres are probably temporary here

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -37,7 +37,11 @@
 #include "cryptonote_format_utils.h"
 #include "cryptonote_boost_serialization.h"
 #include "cryptonote_config.h"
+#if BLOCKCHAIN_DB == DB_LMDB
 #include "blockchain.h"
+#else
+#include "blockchain_storage.h"
+#endif
 #include "common/boost_serialization_helper.h"
 #include "common/int-util.h"
 #include "misc_language.h"
@@ -52,12 +56,19 @@ namespace cryptonote
   {
     size_t const TRANSACTION_SIZE_LIMIT = (((CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE * 125) / 100) - CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE);
   }
-
+  //---------------------------------------------------------------------------------
+#if BLOCKCHAIN_DB == DB_LMDB
   //---------------------------------------------------------------------------------
   tx_memory_pool::tx_memory_pool(Blockchain& bchs): m_blockchain(bchs)
   {
 
   }
+#else
+  tx_memory_pool::tx_memory_pool(blockchain_storage& bchs): m_blockchain(bchs)
+  {
+
+  }
+#endif
   //---------------------------------------------------------------------------------
   bool tx_memory_pool::add_tx(const transaction &tx, /*const crypto::hash& tx_prefix_hash,*/ const crypto::hash &id, size_t blob_size, tx_verification_context& tvc, bool kept_by_block)
   {

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -44,10 +44,13 @@
 #include "verification_context.h"
 #include "crypto/hash.h"
 
-
 namespace cryptonote
 {
+#if BLOCKCHAIN_DB == DB_LMDB
   class Blockchain;
+#else
+  class blockchain_storage;
+#endif
   /************************************************************************/
   /*                                                                      */
   /************************************************************************/
@@ -55,7 +58,11 @@ namespace cryptonote
   class tx_memory_pool: boost::noncopyable
   {
   public:
+#if BLOCKCHAIN_DB == DB_LMDB
     tx_memory_pool(Blockchain& bchs);
+#else
+    tx_memory_pool(blockchain_storage& bchs);
+#endif
     bool add_tx(const transaction &tx, const crypto::hash &id, size_t blob_size, tx_verification_context& tvc, bool keeped_by_block);
     bool add_tx(const transaction &tx, tx_verification_context& tvc, bool keeped_by_block);
     //gets tx and remove it from pool
@@ -127,7 +134,11 @@ namespace cryptonote
     //transactions_container m_alternative_transactions;
 
     std::string m_config_folder;
+#if BLOCKCHAIN_DB == DB_LMDB
     Blockchain& m_blockchain;
+#else
+    blockchain_storage& m_blockchain;
+#endif
     /************************************************************************/
     /*                                                                      */
     /************************************************************************/
@@ -170,6 +181,12 @@ namespace cryptonote
       uint64_t operator()(const txin_to_scripthash& tx) const {return 0;}
     };
 
+#if BLOCKCHAIN_DB == DB_LMDB
+#else
+#if defined(DEBUG_CREATE_BLOCK_TEMPLATE)
+    friend class blockchain_storage;
+#endif
+#endif
   };
 }
 


### PR DESCRIPTION
Usage:

default is lmdb for blockchain branch:
$ make release

same as:
$ DATABASE=lmdb make release

for original in-memory implementation:
$ DATABASE=memory make release