### PR TITLE
Fix Blockchain::get_tail_id() to set parameter to last block number instead of height

### DIFF
--- a/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
+++ b/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
@@ -1053,7 +1053,7 @@ uint64_t BlockchainLMDB::height() const
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   check_open();
 
-  return m_height - 1;
+  return m_height;
 }
 
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -463,7 +463,7 @@ crypto::hash Blockchain::get_tail_id(uint64_t& height) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
-  height = m_db->height();
+  height = m_db->height() - 1;
   return get_tail_id();
 }
 //------------------------------------------------------------------


### PR DESCRIPTION
This reflects the behavior of blockchain_storage::get_tail_id().

Fixes #27 so that RPC method getlastblockheader works.
Test with:
curl 127.0.0.1:18081/json_rpc  -d '{"jsonrpc":"2.0","id":"curl","method":"getlastblockheader","params":{}}' -H "Content-Type: application/json" 