### PR TITLE
DB batch transaction support, profiling, and misc updates

### DIFF
--- a/src/blockchain_converter/blockchain_converter.cpp
+++ b/src/blockchain_converter/blockchain_converter.cpp
@@ -1,21 +1,21 @@
-// Copyright (c) 2014, The Monero Project
-// 
+// Copyright (c) 2014-2015, The Monero Project
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL

--- a/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
+++ b/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
@@ -1563,6 +1563,7 @@ uint64_t BlockchainLMDB::add_block( const block& blk
 
 void BlockchainLMDB::pop_block(block& blk, std::vector<transaction>& txs)
 {
+  LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   txn_safe txn;
   if (mdb_txn_begin(m_env, NULL, 0, txn))
     throw0(DB_ERROR("Failed to create a transaction for the db"));

--- a/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
+++ b/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
@@ -386,7 +386,6 @@ void BlockchainLMDB::remove_output(const uint64_t& out_index, const uint64_t amo
   check_open();
 
   MDB_val_copy<uint64_t> k(out_index);
-  MDB_val v;
 
 /****** Uncomment if ever outputs actually need to be stored in this manner
   blobdata b;

--- a/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
+++ b/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
@@ -33,6 +33,7 @@
 
 #include "cryptonote_core/cryptonote_format_utils.h"
 #include "crypto/crypto.h"
+#include "profile_tools.h"
 
 using epee::string_tools::pod_to_hex;
 
@@ -1666,7 +1667,10 @@ void BlockchainLMDB::batch_commit()
     throw0(DB_ERROR("batch transaction not in progress"));
   check_open();
   LOG_PRINT_L3("batch transaction: committing...");
+  TIME_MEASURE_START(time1);
   m_write_txn->commit();
+  TIME_MEASURE_FINISH(time1);
+  time_commit1 += time1;
   LOG_PRINT_L3("batch transaction: committed");
 
   if (mdb_txn_begin(m_env, NULL, 0, m_write_batch_txn))
@@ -1685,7 +1689,10 @@ void BlockchainLMDB::batch_stop()
     throw0(DB_ERROR("batch transaction not in progress"));
   check_open();
   LOG_PRINT_L3("batch transaction: committing...");
+  TIME_MEASURE_START(time1);
   m_write_txn->commit();
+  TIME_MEASURE_FINISH(time1);
+  time_commit1 += time1;
   // for destruction of batch transaction
   m_write_txn = nullptr;
   m_batch_active = false;
@@ -1741,7 +1748,10 @@ uint64_t BlockchainLMDB::add_block( const block& blk
     {
       m_write_txn = NULL;
 
+      TIME_MEASURE_START(time1);
       txn.commit();
+      TIME_MEASURE_FINISH(time1);
+      time_commit1 += time1;
     }
   }
   catch (...)

--- a/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
+++ b/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
@@ -152,12 +152,13 @@ void BlockchainLMDB::add_block( const block& blk
               , const size_t& block_size
               , const difficulty_type& cumulative_difficulty
               , const uint64_t& coins_generated
+              , const crypto::hash& blk_hash
               )
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   check_open();
 
-  MDB_val_copy<crypto::hash> val_h(get_block_hash(blk));
+  MDB_val_copy<crypto::hash> val_h(blk_hash);
   MDB_val unused;
   if (mdb_get(*m_write_txn, m_block_heights, &val_h, &unused) == 0)
     throw1(BLOCK_EXISTS("Attempting to add block that's already in the db"));
@@ -243,12 +244,12 @@ void BlockchainLMDB::remove_block()
       throw1(DB_ERROR("Failed to add removal of block hash to db transaction"));
 }
 
-void BlockchainLMDB::add_transaction_data(const crypto::hash& blk_hash, const transaction& tx)
+void BlockchainLMDB::add_transaction_data(const crypto::hash& blk_hash, const transaction& tx, const crypto::hash& tx_hash)
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   check_open();
 
-  MDB_val_copy<crypto::hash> val_h(get_transaction_hash(tx));
+  MDB_val_copy<crypto::hash> val_h(tx_hash);
   MDB_val unused;
   if (mdb_get(*m_write_txn, m_txs, &val_h, &unused) == 0)
       throw1(TX_EXISTS("Attempting to add transaction that's already in the db"));

--- a/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
+++ b/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
@@ -1126,7 +1126,6 @@ uint64_t BlockchainLMDB::height() const
   return m_height;
 }
 
-
 bool BlockchainLMDB::tx_exists(const crypto::hash& h) const
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
@@ -1144,7 +1143,11 @@ bool BlockchainLMDB::tx_exists(const crypto::hash& h) const
 
   MDB_val_copy<crypto::hash> key(h);
   MDB_val result;
+
+  TIME_MEASURE_START(time1);
   auto get_result = mdb_get(*txn_ptr, m_txs, &key, &result);
+  TIME_MEASURE_FINISH(time1);
+  time_tx_exists += time1;
   if (get_result == MDB_NOTFOUND)
   {
     if (! m_batch_active)

--- a/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
+++ b/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
@@ -675,7 +675,7 @@ void BlockchainLMDB::open(const std::string& filename)
   lmdb_db_open(txn, LMDB_OUTPUT_GINDICES, MDB_CREATE, m_output_gindices, "Failed to open db handle for m_output_gindices");
 *************************************************/
 
-  lmdb_db_open(txn, LMDB_SPENT_KEYS, MDB_CREATE, m_spent_keys, "Failed to open db handle for m_outputs");
+  lmdb_db_open(txn, LMDB_SPENT_KEYS, MDB_CREATE, m_spent_keys, "Failed to open db handle for m_spent_keys");
 
   mdb_set_dupsort(txn, m_output_amounts, compare_uint64);
   mdb_set_dupsort(txn, m_tx_outputs, compare_uint64);

--- a/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
+++ b/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
@@ -630,6 +630,16 @@ void BlockchainLMDB::open(const std::string& filename)
       throw0(DB_OPEN_FAILURE(std::string("Failed to create directory ").append(filename).c_str()));
   }
 
+  // check for existing LMDB files in base directory
+  boost::filesystem::path old_files = direc.parent_path();
+  if (boost::filesystem::exists(old_files / "data.mdb") ||
+      boost::filesystem::exists(old_files / "lock.mdb"))
+  {
+    LOG_PRINT_L0("Found existing LMDB files in " << old_files.c_str());
+    LOG_PRINT_L0("Move data.mdb and/or lock.mdb to " << filename << ", or delete them, and then restart");
+    throw DB_ERROR("Database could not be opened");
+  }
+
   m_folder = filename;
 
   // set up lmdb environment

--- a/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
+++ b/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
@@ -742,6 +742,7 @@ void BlockchainLMDB::close()
 void BlockchainLMDB::sync()
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
+  check_open();
 
   // Does nothing unless LMDB environment was opened with MDB_NOSYNC or in part
   // MDB_NOMETASYNC. Force flush to be synchronous.
@@ -1757,6 +1758,8 @@ uint64_t BlockchainLMDB::add_block( const block& blk
 void BlockchainLMDB::pop_block(block& blk, std::vector<transaction>& txs)
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
+  check_open();
+
   txn_safe txn;
   if (! m_batch_active)
   {

--- a/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
+++ b/src/cryptonote_core/BlockchainDB_impl/db_lmdb.cpp
@@ -756,7 +756,6 @@ void BlockchainLMDB::unlock()
   check_open();
 }
 
-
 bool BlockchainLMDB::block_exists(const crypto::hash& h) const
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
@@ -772,7 +771,7 @@ bool BlockchainLMDB::block_exists(const crypto::hash& h) const
   if (get_result == MDB_NOTFOUND)
   {
     txn.commit();
-    LOG_PRINT_L1("Block with hash " << epee::string_tools::pod_to_hex(h) << "not found in db");
+    LOG_PRINT_L1("Block with hash " << epee::string_tools::pod_to_hex(h) << " not found in db");
     return false;
   }
   else if (get_result)
@@ -1075,7 +1074,7 @@ bool BlockchainLMDB::tx_exists(const crypto::hash& h) const
   if (get_result == MDB_NOTFOUND)
   {
     txn.commit();
-    LOG_PRINT_L1("transaction with hash " << epee::string_tools::pod_to_hex(h) << "not found in db");
+    LOG_PRINT_L1("transaction with hash " << epee::string_tools::pod_to_hex(h) << " not found in db");
     return false;
   }
   else if (get_result)
@@ -1097,7 +1096,7 @@ uint64_t BlockchainLMDB::get_tx_unlock_time(const crypto::hash& h) const
   MDB_val result;
   auto get_result = mdb_get(txn, m_tx_unlocks, &key, &result);
   if (get_result == MDB_NOTFOUND)
-    throw1(TX_DNE(std::string("tx unlock time with hash ").append(epee::string_tools::pod_to_hex(h)).append("not found in db").c_str()));
+    throw1(TX_DNE(std::string("tx unlock time with hash ").append(epee::string_tools::pod_to_hex(h)).append(" not found in db").c_str()));
   else if (get_result)
     throw0(DB_ERROR("DB error attempting to fetch tx unlock time from hash"));
 
@@ -1117,7 +1116,7 @@ transaction BlockchainLMDB::get_tx(const crypto::hash& h) const
   MDB_val result;
   auto get_result = mdb_get(txn, m_txs, &key, &result);
   if (get_result == MDB_NOTFOUND)
-    throw1(TX_DNE(std::string("tx with hash ").append(epee::string_tools::pod_to_hex(h)).append("not found in db").c_str()));
+    throw1(TX_DNE(std::string("tx with hash ").append(epee::string_tools::pod_to_hex(h)).append(" not found in db").c_str()));
   else if (get_result)
     throw0(DB_ERROR("DB error attempting to fetch tx from hash"));
 
@@ -1177,7 +1176,7 @@ uint64_t BlockchainLMDB::get_tx_block_height(const crypto::hash& h) const
   auto get_result = mdb_get(txn, m_tx_heights, &key, &result);
   if (get_result == MDB_NOTFOUND)
   {
-    throw1(TX_DNE(std::string("tx height with hash ").append(epee::string_tools::pod_to_hex(h)).append("not found in db").c_str()));
+    throw1(TX_DNE(std::string("tx height with hash ").append(epee::string_tools::pod_to_hex(h)).append(" not found in db").c_str()));
   }
   else if (get_result)
     throw0(DB_ERROR("DB error attempting to fetch tx height from hash"));

--- a/src/cryptonote_core/BlockchainDB_impl/db_lmdb.h
+++ b/src/cryptonote_core/BlockchainDB_impl/db_lmdb.h
@@ -184,11 +184,12 @@ private:
                 , const size_t& block_size
                 , const difficulty_type& cumulative_difficulty
                 , const uint64_t& coins_generated
+                , const crypto::hash& block_hash
                 );
 
   virtual void remove_block();
 
-  virtual void add_transaction_data(const crypto::hash& blk_hash, const transaction& tx);
+  virtual void add_transaction_data(const crypto::hash& blk_hash, const transaction& tx, const crypto::hash& tx_hash);
 
   virtual void remove_transaction_data(const crypto::hash& tx_hash, const transaction& tx);
 

--- a/src/cryptonote_core/BlockchainDB_impl/db_lmdb.h
+++ b/src/cryptonote_core/BlockchainDB_impl/db_lmdb.h
@@ -38,8 +38,23 @@ struct txn_safe
   txn_safe() : m_txn(NULL) { }
   ~txn_safe()
   {
-    if(m_txn != NULL)
+    LOG_PRINT_L3("txn_safe: destructor");
+    if (m_txn != NULL)
     {
+      if (m_batch_txn) // this is a batch txn and should have been handled before this point for safety
+      {
+        LOG_PRINT_L0("WARNING: txn_safe: m_txn is a batch txn and it's not NULL in destructor - calling mdb_txn_abort()");
+      }
+      else
+      {
+        // Example of when this occurs: a lookup fails, so a read-only txn is
+        // aborted through this destructor. However, successful read-only txns
+        // ideally should have been committed when done and not end up here.
+        //
+        // NOTE: not sure if this is ever reached for a non-batch write
+        // transaction, but it's probably not ideal if it did.
+        LOG_PRINT_L3("txn_safe: m_txn not NULL in destructor - calling mdb_txn_abort()");
+      }
       mdb_txn_abort(m_txn);
     }
   }
@@ -60,6 +75,24 @@ struct txn_safe
     m_txn = NULL;
   }
 
+  // This should only be needed for batch transaction which must be ensured to
+  // be aborted before mdb_env_close, not after. So we can't rely on
+  // BlockchainLMDB destructor to call txn_safe destructor, as that's too late
+  // to properly abort, since mdb_env_close would have been called earlier.
+  void abort()
+  {
+    LOG_PRINT_L3("txn_safe: abort()");
+    if(m_txn != NULL)
+    {
+      mdb_txn_abort(m_txn);
+      m_txn = NULL;
+    }
+    else
+    {
+      LOG_PRINT_L0("WARNING: txn_safe: abort() called, but m_txn is NULL");
+    }
+  }
+
   operator MDB_txn*()
   {
     return m_txn;
@@ -71,13 +104,14 @@ struct txn_safe
   }
 
   MDB_txn* m_txn;
+  bool m_batch_txn = false;
 };
 
 
 class BlockchainLMDB : public BlockchainDB
 {
 public:
-  BlockchainLMDB();
+  BlockchainLMDB(bool batch_transactions=false);
   ~BlockchainLMDB();
 
   virtual void open(const std::string& filename);
@@ -177,6 +211,12 @@ public:
                             , const std::vector<transaction>& txs
                             );
 
+  virtual void set_batch_transactions(bool batch_transactions);
+  virtual void batch_start();
+  virtual void batch_commit();
+  virtual void batch_stop();
+  virtual void batch_abort();
+
   virtual void pop_block(block& blk, std::vector<transaction>& txs);
 
 private:
@@ -264,7 +304,11 @@ private:
   uint64_t m_height;
   uint64_t m_num_outputs;
   std::string m_folder;
-  txn_safe* m_write_txn;
+  txn_safe* m_write_txn; // may point to either a short-lived txn or a batch txn
+  txn_safe m_write_batch_txn; // persist batch txn outside of BlockchainLMDB
+
+  bool m_batch_transactions; // support for batch transactions
+  bool m_batch_active; // whether batch transaction is in progress
 };
 
 }  // namespace cryptonote

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -237,8 +237,9 @@ bool Blockchain::init(const std::string& config_folder, bool testnet)
   m_testnet = testnet;
 
   boost::filesystem::path folder(m_config_folder);
+  folder /= "lmdb";
 
-  LOG_PRINT_L0("Loading blockchain...");
+  LOG_PRINT_L0("Loading blockchain from folder " << folder.c_str() << " ...");
 
   //FIXME: update filename for BlockchainDB
   const std::string filename = folder.string();

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2288,7 +2288,7 @@ bool Blockchain::add_new_block(const block& bl_, block_verification_context& bvc
   return handle_block_to_main_chain(bl, id, bvc);
 }
 //------------------------------------------------------------------
-void Blockchain::check_against_checkpoints(checkpoints& points, bool enforce)
+void Blockchain::check_against_checkpoints(const checkpoints& points, bool enforce)
 {
   const auto& pts = points.get_points();
 

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -141,7 +141,7 @@ namespace cryptonote
     void print_blockchain_index();
     void print_blockchain_outs(const std::string& file);
 
-    void check_against_checkpoints(checkpoints& points, bool enforce);
+    void check_against_checkpoints(const checkpoints& points, bool enforce);
     void set_enforce_dns_checkpoints(bool enforce);
     bool update_checkpoints(const std::string& file_path, bool check_dns);
 

--- a/src/cryptonote_core/blockchain_db.cpp
+++ b/src/cryptonote_core/blockchain_db.cpp
@@ -151,6 +151,7 @@ void BlockchainDB::reset_stats()
   time_blk_hash = 0;
   time_add_block1 = 0;
   time_add_transaction = 0;
+  time_commit1 = 0;
 }
 
 void BlockchainDB::show_stats()
@@ -165,6 +166,8 @@ void BlockchainDB::show_stats()
     << "time_add_block1: " << time_add_block1 << "ms"
     << ENDL
     << "time_add_transaction: " << time_add_transaction << "ms"
+    << ENDL
+    << "time_commit1: " << time_commit1 << "ms"
     << ENDL
     << "*********************************"
     << ENDL

--- a/src/cryptonote_core/blockchain_db.cpp
+++ b/src/cryptonote_core/blockchain_db.cpp
@@ -149,6 +149,7 @@ void BlockchainDB::reset_stats()
 {
   num_calls = 0;
   time_blk_hash = 0;
+  time_tx_exists = 0;
   time_add_block1 = 0;
   time_add_transaction = 0;
   time_commit1 = 0;
@@ -162,6 +163,8 @@ void BlockchainDB::show_stats()
     << "num_calls: " << num_calls
     << ENDL
     << "time_blk_hash: " << time_blk_hash << "ms"
+    << ENDL
+    << "time_tx_exists: " << time_tx_exists << "ms"
     << ENDL
     << "time_add_block1: " << time_add_block1 << "ms"
     << ENDL

--- a/src/cryptonote_core/blockchain_db.h
+++ b/src/cryptonote_core/blockchain_db.h
@@ -310,6 +310,7 @@ private:
 
 protected:
 
+  mutable uint64_t time_tx_exists = 0;
   uint64_t time_commit1 = 0;
 
 

--- a/src/cryptonote_core/blockchain_db.h
+++ b/src/cryptonote_core/blockchain_db.h
@@ -308,6 +308,11 @@ private:
   uint64_t time_add_transaction = 0;
 
 
+protected:
+
+  uint64_t time_commit1 = 0;
+
+
 public:
 
   // virtual dtor

--- a/src/cryptonote_core/blockchain_db.h
+++ b/src/cryptonote_core/blockchain_db.h
@@ -347,6 +347,9 @@ public:
   // release db lock
   virtual void unlock() = 0;
 
+  virtual void batch_start() = 0;
+  virtual void batch_stop() = 0;
+  virtual void set_batch_transactions(bool) = 0;
 
   // adds a block with the given metadata to the top of the blockchain, returns the new height
   // NOTE: subclass implementations of this (or the functions it calls) need

--- a/src/cryptonote_core/blockchain_db.h
+++ b/src/cryptonote_core/blockchain_db.h
@@ -265,13 +265,14 @@ private:
                 , const size_t& block_size
                 , const difficulty_type& cumulative_difficulty
                 , const uint64_t& coins_generated
+                , const crypto::hash& blk_hash
                 ) = 0;
 
   // tells the subclass to remove data about the top block
   virtual void remove_block() = 0;
 
   // tells the subclass to store the transaction and its metadata
-  virtual void add_transaction_data(const crypto::hash& blk_hash, const transaction& tx) = 0;
+  virtual void add_transaction_data(const crypto::hash& blk_hash, const transaction& tx, const crypto::hash& tx_hash) = 0;
 
   // tells the subclass to remove data about a transaction
   virtual void remove_transaction_data(const crypto::hash& tx_hash, const transaction& tx) = 0;
@@ -296,7 +297,7 @@ private:
   void pop_block();
 
   // helper function for add_transactions, to add each individual tx
-  void add_transaction(const crypto::hash& blk_hash, const transaction& tx);
+  void add_transaction(const crypto::hash& blk_hash, const transaction& tx, const crypto::hash* tx_hash_ptr = NULL);
 
   // helper function to remove transaction from blockchain
   void remove_transaction(const crypto::hash& tx_hash);

--- a/src/cryptonote_core/blockchain_db.h
+++ b/src/cryptonote_core/blockchain_db.h
@@ -301,12 +301,22 @@ private:
   // helper function to remove transaction from blockchain
   void remove_transaction(const crypto::hash& tx_hash);
 
+  uint64_t num_calls = 0;
+  uint64_t time_blk_hash = 0;
+  uint64_t time_add_block1 = 0;
+  uint64_t time_add_transaction = 0;
+
 
 public:
 
   // virtual dtor
   virtual ~BlockchainDB() { };
 
+  // reset profiling stats
+  void reset_stats();
+
+  // show profiling stats
+  void show_stats();
 
   // open the db at location <filename>, or create it if there isn't one.
   virtual void open(const std::string& filename) = 0;


### PR DESCRIPTION
Add support to BlockchainDB and BlockchainLMDB for batch transactions.

Add profiling to block and tx processing and DB operations.

Improve block and tx processing efficiency by less repeat hashing.

Move LMDB storage to "lmdb" subfolder.
- Upon startup, if old LMDB files are detected, abort with a message for the user to move them to subfolder or delete them.

Update and fix log statements and formatting.





