### PR TITLE
Add exporter and importer, update blockchain_converter

### DIFF
--- a/src/blockchain_converter/CMakeLists.txt
+++ b/src/blockchain_converter/CMakeLists.txt
@@ -47,6 +47,20 @@ set(blockchain_import_private_headers
 bitmonero_private_headers(blockchain_import
 	  ${blockchain_import_private_headers})
 
+set(blockchain_export_sources
+  blockchain_export.cpp
+  )
+
+set(blockchain_export_private_headers
+  import.h
+  blockchain_export.h
+  )
+
+bitmonero_private_headers(blockchain_export
+	  ${blockchain_export_private_headers})
+
+
+
 if (BLOCKCHAIN_DB STREQUAL DB_LMDB)
 bitmonero_add_executable(blockchain_converter
   ${blockchain_converter_sources}
@@ -79,3 +93,18 @@ add_dependencies(blockchain_import
 set_property(TARGET blockchain_import
 	PROPERTY
 	OUTPUT_NAME "blockchain_import")
+
+bitmonero_add_executable(blockchain_export
+  ${blockchain_export_sources}
+  ${blockchain_export_private_headers})
+
+target_link_libraries(blockchain_export
+  LINK_PRIVATE
+    cryptonote_core
+    ${CMAKE_THREAD_LIBS_INIT})
+
+add_dependencies(blockchain_export
+	version)
+set_property(TARGET blockchain_export
+	PROPERTY
+	OUTPUT_NAME "blockchain_export")

--- a/src/blockchain_converter/CMakeLists.txt
+++ b/src/blockchain_converter/CMakeLists.txt
@@ -35,6 +35,18 @@ set(blockchain_converter_private_headers)
 bitmonero_private_headers(blockchain_converter
 	  ${blockchain_converter_private_headers})
 
+set(blockchain_import_sources
+  blockchain_import.cpp
+  )
+
+set(blockchain_import_private_headers
+  import.h
+  fake_core.h
+  )
+
+bitmonero_private_headers(blockchain_import
+	  ${blockchain_import_private_headers})
+
 if (BLOCKCHAIN_DB STREQUAL DB_LMDB)
 bitmonero_add_executable(blockchain_converter
   ${blockchain_converter_sources}
@@ -52,3 +64,18 @@ set_property(TARGET blockchain_converter
 	PROPERTY
 	OUTPUT_NAME "blockchain_converter")
 endif ()
+
+bitmonero_add_executable(blockchain_import
+  ${blockchain_import_sources}
+  ${blockchain_import_private_headers})
+
+target_link_libraries(blockchain_import
+  LINK_PRIVATE
+    cryptonote_core
+    ${CMAKE_THREAD_LIBS_INIT})
+
+add_dependencies(blockchain_import
+	version)
+set_property(TARGET blockchain_import
+	PROPERTY
+	OUTPUT_NAME "blockchain_import")

--- a/src/blockchain_converter/blockchain_converter.cpp
+++ b/src/blockchain_converter/blockchain_converter.cpp
@@ -38,52 +38,179 @@
 #include "cryptonote_core/blockchain.h"
 #include "blockchain_db/lmdb/db_lmdb.h"
 #include "cryptonote_core/tx_pool.h"
+#include "common/command_line.h"
+#include "serialization/json_utils.h"
+#include "include_base_utils.h"
+#include "version.h"
 #include <iostream>
 
+// CONFIG
+static bool opt_batch   = true;
+static bool opt_testnet = false;
+
+// number of blocks per batch transaction
+// adjustable through command-line argument according to available RAM
+static uint64_t db_batch_size = 20000;
+
+
+namespace po = boost::program_options;
+
 using namespace cryptonote;
+using namespace epee;
 
 struct fake_core
 {
-  tx_memory_pool m_pool;
   Blockchain dummy;
+  tx_memory_pool m_pool;
 
   blockchain_storage m_storage;
 
-
-  fake_core(const boost::filesystem::path &path) : m_pool(dummy), dummy(m_pool), m_storage(&m_pool)
+#if !defined(BLOCKCHAIN_DB)
+  // for multi_db_runtime:
+  fake_core(const boost::filesystem::path &path, const bool use_testnet) : dummy(m_pool), m_pool(&dummy), m_storage(m_pool)
+#else
+  // for multi_db_compile:
+  fake_core(const boost::filesystem::path &path, const bool use_testnet) : dummy(m_pool), m_pool(dummy), m_storage(&m_pool)
+#endif
   {
     m_pool.init(path.string());
-    m_storage.init(path.string(), false);
+    m_storage.init(path.string(), use_testnet);
   }
 };
 
 int main(int argc, char* argv[])
 {
-  std::string dir = tools::get_default_data_dir();
-  boost::filesystem::path default_data_path {dir};
-  if (argc >= 2 && !strcmp(argv[1], "--testnet")) {
-    default_data_path /= "testnet";
+  uint64_t height = 0;
+  uint64_t start_block = 0;
+  uint64_t end_block = 0;
+  uint64_t num_blocks = 0;
+
+  boost::filesystem::path default_data_path {tools::get_default_data_dir()};
+  boost::filesystem::path default_testnet_data_path {default_data_path / "testnet"};
+
+
+  po::options_description desc_cmd_only("Command line options");
+  po::options_description desc_cmd_sett("Command line options and settings options");
+  const command_line::arg_descriptor<uint32_t> arg_log_level   =  {"log-level", "", LOG_LEVEL_0};
+  const command_line::arg_descriptor<uint64_t> arg_batch_size  =  {"batch-size", "", db_batch_size};
+  const command_line::arg_descriptor<bool>     arg_testnet_on  = {
+    "testnet"
+      , "Run on testnet."
+      , opt_testnet
+  };
+  const command_line::arg_descriptor<uint64_t> arg_block_number =
+  {"block-number", "Number of blocks (default: use entire source blockchain)",
+    0};
+
+  command_line::add_arg(desc_cmd_sett, command_line::arg_data_dir, default_data_path.string());
+  command_line::add_arg(desc_cmd_sett, command_line::arg_testnet_data_dir, default_testnet_data_path.string());
+  command_line::add_arg(desc_cmd_sett, arg_log_level);
+  command_line::add_arg(desc_cmd_sett, arg_batch_size);
+  command_line::add_arg(desc_cmd_sett, arg_testnet_on);
+  command_line::add_arg(desc_cmd_sett, arg_block_number);
+
+  command_line::add_arg(desc_cmd_only, command_line::arg_help);
+
+  const command_line::arg_descriptor<bool> arg_batch  =  {"batch",
+    "Batch transactions for faster import", true};
+
+  // call add_options() directly for these arguments since command_line helpers
+  // support only boolean switch, not boolean argument
+  desc_cmd_sett.add_options()
+    (arg_batch.name, make_semantic(arg_batch), arg_batch.description)
+    ;
+
+  po::options_description desc_options("Allowed options");
+  desc_options.add(desc_cmd_only).add(desc_cmd_sett);
+
+
+  po::variables_map vm;
+  bool r = command_line::handle_error_helper(desc_options, [&]()
+  {
+    po::store(po::parse_command_line(argc, argv, desc_options), vm);
+    po::notify(vm);
+
+    return true;
+  });
+  if (!r)
+    return 1;
+
+  int log_level = command_line::get_arg(vm, arg_log_level);
+  opt_batch     = command_line::get_arg(vm, arg_batch);
+  db_batch_size = command_line::get_arg(vm, arg_batch_size);
+
+  if (command_line::get_arg(vm, command_line::arg_help))
+  {
+    std::cout << CRYPTONOTE_NAME << " v" << MONERO_VERSION_FULL << ENDL << ENDL;
+    std::cout << desc_options << std::endl;
+    return 1;
   }
 
-  fake_core c(default_data_path);
+  if (! opt_batch && ! vm["batch-size"].defaulted())
+  {
+    std::cerr << "Error: batch-size set, but batch option not enabled" << ENDL;
+    return 1;
+  }
+  if (! db_batch_size)
+  {
+    std::cerr << "Error: batch-size must be > 0" << ENDL;
+    return 1;
+  }
+
+  log_space::get_set_log_detalisation_level(true, log_level);
+  log_space::log_singletone::add_logger(LOGGER_CONSOLE, NULL, NULL);
+  LOG_PRINT_L0("Starting...");
+
+  std::string src_folder;
+  opt_testnet = command_line::get_arg(vm, arg_testnet_on);
+  auto data_dir_arg = opt_testnet ? command_line::arg_testnet_data_dir : command_line::arg_data_dir;
+  src_folder = command_line::get_arg(vm, data_dir_arg);
+  boost::filesystem::path dest_folder(src_folder);
+
+  num_blocks = command_line::get_arg(vm, arg_block_number);
+
+  if (opt_batch)
+  {
+    LOG_PRINT_L0("batch:   " << std::boolalpha << opt_batch << std::noboolalpha
+        << "  batch size: " << db_batch_size);
+  }
+  else
+  {
+    LOG_PRINT_L0("batch:   " << std::boolalpha << opt_batch << std::noboolalpha);
+  }
+  LOG_PRINT_L0("testnet: " << std::boolalpha << opt_testnet << std::noboolalpha);
+
+  fake_core c(src_folder, opt_testnet);
+
+  height = c.m_storage.get_current_blockchain_height();
+  if (! num_blocks || num_blocks > height)
+    end_block = height - 1;
+  else
+    end_block = start_block + num_blocks - 1;
 
   BlockchainDB *blockchain;
+  blockchain = new BlockchainLMDB(opt_batch);
+  dest_folder /= blockchain->get_db_name();
+  LOG_PRINT_L0("Source blockchain: " << src_folder);
+  LOG_PRINT_L0("Dest blockchain:   " << dest_folder.string());
+  LOG_PRINT_L0("Opening LMDB: " << dest_folder.string());
+  blockchain->open(dest_folder.string());
 
-  blockchain = new BlockchainLMDB();
-
-  boost::filesystem::path db_path(default_data_path);
-
-  db_path /= blockchain->get_db_name();
-
-  blockchain->open(db_path.string());
-
-  for (uint64_t height, i = 0; i < (height = c.m_storage.get_current_blockchain_height()); ++i)
+  if (opt_batch)
+    blockchain->batch_start();
+  uint64_t i = 0;
+  for (i = start_block; i < end_block + 1; ++i)
   {
-    if (i % 10 == 0)
+    // block: i  height: i+1  end height: end_block + 1
+    if ((i+1) % 10 == 0)
     {
-      std::cout << "\r                   \r" << "block " << i << "/" << height
-         << " (" << (i+1)*100/height<< "%)" << std::flush;
+      std::cout << "\r                   \r" << "height " << i+1 << "/" <<
+        end_block+1 << " (" << (i+1)*100/(end_block+1)<< "%)" << std::flush;
     }
+    // for debugging:
+    // std::cout << "height " << i+1 << "/" << end_block+1
+    //   << " ((" << i+1 << ")*100/(end_block+1))" << "%)" << ENDL;
+
     block b = c.m_storage.get_block(i);
     size_t bsize = c.m_storage.get_block_size(i);
     difficulty_type bdiff = c.m_storage.get_block_cumulative_difficulty(i);
@@ -94,8 +221,8 @@ int main(int argc, char* argv[])
     c.m_storage.get_transactions(b.tx_hashes, txs, missed);
     if (missed.size())
     {
-      std::cout << std::endl;
-      std::cerr << "Missed transaction(s) for block at height " << i << ", exiting" << std::endl;
+      std::cout << ENDL;
+      std::cerr << "Missed transaction(s) for block at height " << i + 1 << ", exiting" << ENDL;
       delete blockchain;
       return 1;
     }
@@ -103,17 +230,40 @@ int main(int argc, char* argv[])
     try
     {
       blockchain->add_block(b, bsize, bdiff, bcoins, txs);
+
+      if (opt_batch)
+      {
+        if ((i < end_block) && ((i + 1) % db_batch_size == 0))
+        {
+          std::cout << "\r                   \r";
+          std::cout << "[- batch commit at height " << i + 1 << " -]" << ENDL;
+          blockchain->batch_stop();
+          blockchain->batch_start();
+          std::cout << ENDL;
+          blockchain->show_stats();
+        }
+      }
     }
     catch (const std::exception& e)
     {
-      std::cout << std::endl;
-      std::cerr << "Error adding block to new blockchain: " << e.what() << std::endl;
+      std::cout << ENDL;
+      std::cerr << "Error adding block to new blockchain: " << e.what() << ENDL;
       delete blockchain;
       return 2;
     }
   }
+  if (opt_batch)
+  {
+    std::cout << "\r                   \r" << "height " << i << "/" <<
+      end_block+1 << " (" << (i)*100/(end_block+1)<< "%)" << std::flush;
+    std::cout << ENDL;
+    std::cout << "[- batch commit at height " << i << " -]" << ENDL;
+    blockchain->batch_stop();
+  }
+  std::cout << ENDL;
+  blockchain->show_stats();
+  std::cout << "Finished at height: " << i << "  block: " << i-1 << ENDL;
 
-  std::cout << std::endl;
   delete blockchain;
   return 0;
 }

--- a/src/blockchain_converter/blockchain_export.cpp
+++ b/src/blockchain_converter/blockchain_export.cpp
@@ -1,0 +1,367 @@
+// Copyright (c) 2014-2015, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <algorithm>
+#include <cstdio>
+#include <fstream>
+#include <boost/iostreams/copy.hpp>
+#include <atomic>
+
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/iostreams/stream_buffer.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <boost/iostreams/device/back_inserter.hpp>
+#include <boost/iostreams/filtering_streambuf.hpp>
+#include <boost/iostreams/filter/bzip2.hpp>
+#include "common/command_line.h"
+#include "version.h"
+#include "blockchain_export.h"
+#include "cryptonote_core/cryptonote_boost_serialization.h"
+
+#include "import.h"
+// #include "fake_core.h"
+
+#define SOURCE_DB DB_MEMORY
+// currently not supported:
+// to use what was set at compile time (DB_MEMORY or DB_LMDB)
+// #define SOURCE_DB BLOCKCHAIN_DB
+
+static int max_chunk = 0;
+static size_t height;
+
+namespace po = boost::program_options;
+
+using namespace cryptonote;
+using namespace epee;
+
+bool BlockchainExport::open(const boost::filesystem::path& dir_path)
+{
+  if (boost::filesystem::exists(dir_path))
+  {
+    if (!boost::filesystem::is_directory(dir_path))
+    {
+      LOG_PRINT_RED_L0("export directory path is a file: " << dir_path);
+      return false;
+    }
+  }
+  else
+  {
+    if (!boost::filesystem::create_directory(dir_path))
+    {
+      LOG_PRINT_RED_L0("Failed to create directory " << dir_path);
+      return false;
+    }
+  }
+
+  std::string file_path = (dir_path / BLOCKCHAIN_RAW).string();
+  m_raw_data_file = new std::ofstream();
+  m_raw_data_file->open(file_path , std::ios_base::binary | std::ios_base::out| std::ios::trunc);
+  if (m_raw_data_file->fail())
+    return false;
+
+  m_output_stream = new boost::iostreams::stream<boost::iostreams::back_insert_device<buffer_type>>(m_buffer);
+  m_raw_archive = new boost::archive::binary_oarchive(*m_output_stream);
+  if (m_raw_archive == NULL)
+    return false;
+
+  return true;
+}
+
+void BlockchainExport::flush_chunk()
+{
+  m_output_stream->flush();
+  char buffer[STR_LENGTH_OF_INT + 1];
+  int chunk_size = (int) m_buffer.size();
+  if (chunk_size > BUFFER_SIZE)
+  {
+    LOG_PRINT_L0("WARNING: chunk_size " << chunk_size << " > BUFFER_SIZE " << BUFFER_SIZE);
+  }
+  sprintf(buffer, STR_FORMAT_OF_INT, chunk_size);
+  m_raw_data_file->write(buffer, STR_LENGTH_OF_INT);
+  if (max_chunk < chunk_size)
+  {
+    max_chunk = chunk_size;
+  }
+  long pos_before = m_raw_data_file->tellp();
+  std::copy(m_buffer.begin(), m_buffer.end(), std::ostreambuf_iterator<char>(*m_raw_data_file));
+  m_raw_data_file->flush();
+  long pos_after = m_raw_data_file->tellp();
+  long num_chars_written = pos_after - pos_before;
+  if ((int) num_chars_written != chunk_size)
+  {
+    LOG_PRINT_RED_L0("INTERNAL ERROR: num chars wrote NEQ buffer size. height = " << height);
+  }
+
+  m_buffer.clear();
+  delete m_raw_archive;
+  delete m_output_stream;
+  m_output_stream = new boost::iostreams::stream<boost::iostreams::back_insert_device<buffer_type>>(m_buffer);
+  m_raw_archive = new boost::archive::binary_oarchive(*m_output_stream);
+}
+
+void BlockchainExport::serialize_block_to_text_buffer(const block& block)
+{
+  *m_raw_archive << block;
+}
+
+void BlockchainExport::buffer_serialize_tx(const transaction& tx)
+{
+  *m_raw_archive << tx;
+}
+
+void BlockchainExport::buffer_write_num_txs(const std::list<transaction> txs)
+{
+  int n = txs.size();
+  *m_raw_archive << n;
+}
+
+void BlockchainExport::write_block(block& block)
+{
+  serialize_block_to_text_buffer(block);
+  std::list<transaction> txs;
+
+  uint64_t block_height = boost::get<txin_gen>(block.miner_tx.vin.front()).height;
+
+  // put coinbase transaction first
+  transaction coinbase_tx = block.miner_tx;
+  crypto::hash coinbase_tx_hash = get_transaction_hash(coinbase_tx);
+  // blockchain_storage:
+  const transaction* cb_tx_full = m_blockchain_storage->get_tx(coinbase_tx_hash);
+  //
+  // BlockchainDB:
+  // transaction cb_tx_full = m_blockchain_storage->get_tx(coinbase_tx_hash);
+
+
+  // blockchain_storage:
+  if (cb_tx_full != NULL)
+  {
+    txs.push_back(*cb_tx_full);
+  }
+  //
+  // BlockchainDB:
+  // txs.push_back(cb_tx_full);
+
+  // now add all regular transactions
+  BOOST_FOREACH(const auto& tx_id, block.tx_hashes)
+  {
+#if SOURCE_DB == DB_MEMORY
+    const transaction* tx = m_blockchain_storage->get_tx(tx_id);
+#else
+    transaction tx = m_blockchain_storage->get_tx(tx_id);
+#endif
+
+#if SOURCE_DB == DB_MEMORY
+    if(tx == NULL)
+    {
+      if (! m_tx_pool)
+        throw std::runtime_error("Aborting: tx == NULL, so memory pool required to get tx, but memory pool isn't enabled");
+      else
+      {
+        transaction tx;
+        if(m_tx_pool->get_transaction(tx_id, tx))
+          txs.push_back(tx);
+        else
+          throw std::runtime_error("Aborting: tx not found in pool");
+      }
+    }
+    else
+      txs.push_back(*tx);
+#else
+    txs.push_back(tx);
+#endif
+  }
+
+  // serialize all txs to the persistant storage
+  buffer_write_num_txs(txs);
+  BOOST_FOREACH(const auto& tx, txs)
+  {
+    buffer_serialize_tx(tx);
+  }
+
+  // These three attributes are currently necessary for a fast import that adds blocks without verification.
+  bool include_extra_block_data = true;
+  if (include_extra_block_data)
+  {
+    size_t block_size = m_blockchain_storage->get_block_size(block_height);
+    difficulty_type cumulative_difficulty = m_blockchain_storage->get_block_cumulative_difficulty(block_height);
+    uint64_t coins_generated = m_blockchain_storage->get_block_coins_generated(block_height);
+
+    *m_raw_archive << block_size;
+    *m_raw_archive << cumulative_difficulty;
+    *m_raw_archive << coins_generated;
+  }
+}
+
+bool BlockchainExport::BlockchainExport::close()
+{
+  if (m_raw_data_file->fail())
+    return false;
+
+  m_raw_data_file->flush();
+  delete m_raw_archive;
+  delete m_output_stream;
+  delete m_raw_data_file;
+  return true;
+}
+
+
+#if SOURCE_DB == DB_MEMORY
+bool BlockchainExport::store_blockchain_raw(blockchain_storage* _blockchain_storage, tx_memory_pool* _tx_pool, boost::filesystem::path& output_dir, uint64_t use_block_height)
+#else
+bool BlockchainExport::store_blockchain_raw(BlockchainDB* _blockchain_storage, tx_memory_pool* _tx_pool, boost::filesystem::path& output_dir, uint64_t use_block_height)
+#endif
+{
+  uint64_t use_block_height2 = 0;
+  m_blockchain_storage = _blockchain_storage;
+  m_tx_pool = _tx_pool;
+  LOG_PRINT_L0("Storing blocks raw data...");
+  if (!BlockchainExport::open(output_dir))
+  {
+    LOG_PRINT_RED_L0("failed to open raw file for write");
+    return false;
+  }
+  block b;
+  LOG_PRINT_L0("source blockchain height: " <<  m_blockchain_storage->get_current_blockchain_height());
+  LOG_PRINT_L0("requested block height: " << use_block_height);
+  if ((use_block_height > 0) && (use_block_height < m_blockchain_storage->get_current_blockchain_height()))
+    use_block_height2 = use_block_height;
+  else
+  {
+    use_block_height2 = m_blockchain_storage->get_current_blockchain_height();
+    LOG_PRINT_L0("using block height: " << use_block_height2);
+  }
+  for (height=0; height < use_block_height2; ++height)
+  {
+    crypto::hash hash = m_blockchain_storage->get_block_id_by_height(height);
+    m_blockchain_storage->get_block_by_hash(hash, b);
+    write_block(b);
+    if (height % NUM_BLOCKS_PER_CHUNK == 0) {
+      flush_chunk();
+    }
+  }
+  if (height % NUM_BLOCKS_PER_CHUNK != 0)
+  {
+    flush_chunk();
+  }
+
+  LOG_PRINT_L0("longest chunk was " << max_chunk << " bytes");
+  return BlockchainExport::close();
+}
+
+
+int main(int argc, char* argv[])
+{
+  uint32_t log_level = 0;
+  uint64_t block_height = 0;
+  std::string import_filename = BLOCKCHAIN_RAW;
+
+  boost::filesystem::path default_data_path {tools::get_default_data_dir()};
+  boost::filesystem::path default_testnet_data_path {default_data_path / "testnet"};
+
+  po::options_description desc_cmd_only("Command line options");
+  po::options_description desc_cmd_sett("Command line options and settings options");
+  const command_line::arg_descriptor<uint32_t> arg_log_level   =  {"log-level",  "", log_level};
+  const command_line::arg_descriptor<uint64_t> arg_block_height =  {"block-number", "", block_height};
+  const command_line::arg_descriptor<bool>     arg_testnet_on  = {
+    "testnet"
+      , "Run on testnet."
+      , false
+  };
+
+
+  command_line::add_arg(desc_cmd_sett, command_line::arg_data_dir, default_data_path.string());
+  command_line::add_arg(desc_cmd_sett, command_line::arg_testnet_data_dir, default_testnet_data_path.string());
+  command_line::add_arg(desc_cmd_sett, arg_log_level);
+  command_line::add_arg(desc_cmd_sett, arg_block_height);
+  command_line::add_arg(desc_cmd_sett, arg_testnet_on);
+
+  command_line::add_arg(desc_cmd_only, command_line::arg_help);
+
+  po::options_description desc_options("Allowed options");
+  desc_options.add(desc_cmd_only).add(desc_cmd_sett);
+
+  po::variables_map vm;
+  bool r = command_line::handle_error_helper(desc_options, [&]()
+  {
+    po::store(po::parse_command_line(argc, argv, desc_options), vm);
+    po::notify(vm);
+    return true;
+  });
+  if (! r)
+    return 1;
+
+  if (command_line::get_arg(vm, command_line::arg_help))
+  {
+    std::cout << CRYPTONOTE_NAME << " v" << MONERO_VERSION_FULL << ENDL << ENDL;
+    std::cout << desc_options << std::endl;
+    return 1;
+  }
+
+  log_level    = command_line::get_arg(vm, arg_log_level);
+  block_height = command_line::get_arg(vm, arg_block_height);
+
+  log_space::get_set_log_detalisation_level(true, log_level);
+  log_space::log_singletone::add_logger(LOGGER_CONSOLE, NULL, NULL);
+  LOG_PRINT_L0("Starting...");
+  LOG_PRINT_L0("Setting log level = " << log_level);
+
+  bool opt_testnet = command_line::get_arg(vm, arg_testnet_on);
+
+  std::string m_config_folder;
+
+  auto data_dir_arg = opt_testnet ? command_line::arg_testnet_data_dir : command_line::arg_data_dir;
+  m_config_folder = command_line::get_arg(vm, data_dir_arg);
+  boost::filesystem::path output_dir {m_config_folder};
+  output_dir /= "export";
+  std::cout << "config directory: " << m_config_folder << ENDL;
+
+  // If we wanted to use the memory pool, we would set up a fake_core.
+
+#if SOURCE_DB == DB_MEMORY
+  // blockchain_storage* core_storage = NULL;
+  // tx_memory_pool m_mempool(*core_storage); // is this fake anyway? just passing in NULL! so m_mempool can't be used anyway, right?
+  // core_storage = new blockchain_storage(&m_mempool);
+
+  blockchain_storage* core_storage = new blockchain_storage(NULL);
+#else
+  BlockchainDB* core_storage = new BlockchainLMDB();
+#endif
+  // tx_memory_pool m_mempool(core_storage);
+
+  LOG_PRINT_L0("Initializing source blockchain storage...");
+  r = core_storage->init(m_config_folder, opt_testnet);
+  CHECK_AND_ASSERT_MES(r, false, "Failed to initialize source blockchain storage");
+  LOG_PRINT_L0("Source blockchain storage initialized OK");
+  LOG_PRINT_L0("Exporting blockchain raw data...");
+
+  BlockchainExport be;
+  r = be.store_blockchain_raw(core_storage, NULL, output_dir, block_height);
+  CHECK_AND_ASSERT_MES(r, false, "Failed to export blockchain raw data");
+  LOG_PRINT_L0("Blockchain raw data exported OK");
+}

--- a/src/blockchain_converter/blockchain_export.h
+++ b/src/blockchain_converter/blockchain_export.h
@@ -35,27 +35,40 @@
 #include "cryptonote_core/cryptonote_basic.h"
 #include "cryptonote_core/blockchain_storage.h"
 #include "cryptonote_core/blockchain.h"
-// TODO:
 #include "blockchain_db/blockchain_db.h"
 #include "blockchain_db/lmdb/db_lmdb.h"
+
+// CONFIG: choose one of the three #define's
+//
+// DB_MEMORY is a sensible default for users migrating to LMDB, as it allows
+// the exporter to use the in-memory blockchain while the other binaries
+// work with LMDB, without recompiling anything.
+//
+#define SOURCE_DB DB_MEMORY
+// #define SOURCE_DB DB_LMDB
+// to use global compile-time setting (DB_MEMORY or DB_LMDB):
+// #define SOURCE_DB BLOCKCHAIN_DB
 
 using namespace cryptonote;
 
 class BlockchainExport
 {
 public:
-  bool store_blockchain_raw(cryptonote::blockchain_storage* cs, cryptonote::tx_memory_pool* txp, 
+#if SOURCE_DB == DB_MEMORY
+  bool store_blockchain_raw(cryptonote::blockchain_storage* cs, cryptonote::tx_memory_pool* txp,
       boost::filesystem::path& output_dir, uint64_t use_block_height=0);
-  //
-  // BlockchainDB:
-  // bool store_blockchain_raw(cryptonote::BlockchainDB* cs, boost::filesystem::path& output_dir, uint64_t use_block_height=0);
+#else
+  bool store_blockchain_raw(cryptonote::Blockchain* cs, cryptonote::tx_memory_pool* txp,
+      boost::filesystem::path& output_dir, uint64_t use_block_height=0);
+#endif
 
 protected:
-  // blockchain_storage:
+#if SOURCE_DB == DB_MEMORY
   blockchain_storage* m_blockchain_storage;
-  //
-  // BlockchainDB:
-  // BlockchainDB* m_blockchain_storage;
+#else
+  Blockchain* m_blockchain_storage;
+#endif
+
   tx_memory_pool* m_tx_pool;
   typedef std::vector<char> buffer_type;
   std::ofstream * m_raw_data_file;

--- a/src/blockchain_converter/blockchain_export.h
+++ b/src/blockchain_converter/blockchain_export.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2014-2015, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/iostreams/stream_buffer.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <boost/iostreams/device/back_inserter.hpp>
+#include "cryptonote_core/cryptonote_basic.h"
+#include "cryptonote_core/blockchain_storage.h"
+#include "cryptonote_core/blockchain.h"
+// TODO:
+#include "blockchain_db/blockchain_db.h"
+#include "blockchain_db/lmdb/db_lmdb.h"
+
+using namespace cryptonote;
+
+class BlockchainExport
+{
+public:
+  bool store_blockchain_raw(cryptonote::blockchain_storage* cs, cryptonote::tx_memory_pool* txp, 
+      boost::filesystem::path& output_dir, uint64_t use_block_height=0);
+  //
+  // BlockchainDB:
+  // bool store_blockchain_raw(cryptonote::BlockchainDB* cs, boost::filesystem::path& output_dir, uint64_t use_block_height=0);
+
+protected:
+  // blockchain_storage:
+  blockchain_storage* m_blockchain_storage;
+  //
+  // BlockchainDB:
+  // BlockchainDB* m_blockchain_storage;
+  tx_memory_pool* m_tx_pool;
+  typedef std::vector<char> buffer_type;
+  std::ofstream * m_raw_data_file;
+  boost::archive::binary_oarchive * m_raw_archive;
+  buffer_type m_buffer;
+  boost::iostreams::stream<boost::iostreams::back_insert_device<buffer_type>>* m_output_stream;
+
+  // open export file for write
+  bool open(const boost::filesystem::path& dir_path);
+  bool close();
+  void write_block(block& block);
+  void serialize_block_to_text_buffer(const block& block);
+  void buffer_serialize_tx(const transaction& tx);
+  void buffer_write_num_txs(const std::list<transaction> txs);
+  void flush_chunk();
+};

--- a/src/blockchain_converter/blockchain_import.cpp
+++ b/src/blockchain_converter/blockchain_import.cpp
@@ -1,0 +1,687 @@
+// Copyright (c) 2014-2015, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <atomic>
+#include <cstdio>
+#include <algorithm>
+#include <fstream>
+
+#include <boost/filesystem.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include "cryptonote_core/cryptonote_basic.h"
+#include "cryptonote_core/cryptonote_format_utils.h"
+#include "cryptonote_core/cryptonote_boost_serialization.h"
+#include "serialization/json_utils.h" // dump_json()
+#include "include_base_utils.h"
+#include "common/command_line.h"
+#include "version.h"
+
+
+#include "import.h"
+#include "fake_core.h"
+
+// CONFIG
+static bool opt_batch   = true;
+static bool opt_verify  = true; // use add_new_block, which does verification before calling add_block
+static bool opt_resume  = true;
+static bool opt_testnet = true;
+
+// number of blocks per batch transaction
+// adjustable through command-line argument according to available RAM
+static uint64_t db_batch_size = 20000;
+
+
+namespace po = boost::program_options;
+
+using namespace cryptonote;
+using namespace epee;
+
+int count_blocks(std::string& import_file_path)
+{
+  boost::filesystem::path raw_file_path(import_file_path);
+  boost::system::error_code ec;
+  if (!boost::filesystem::exists(raw_file_path, ec))
+  {
+    LOG_PRINT_L0("import file not found: " << raw_file_path);
+    throw std::runtime_error("Aborting");
+  }
+  std::ifstream import_file;
+  import_file.open(import_file_path, std::ios_base::binary | std::ifstream::in);
+
+  uint64_t h = 0;
+  if (import_file.fail())
+  {
+    LOG_PRINT_L0("import_file.open() fail");
+    throw std::runtime_error("Aborting");
+  }
+  LOG_PRINT_L0("Scanning blockchain from import file...");
+  char buffer1[STR_LENGTH_OF_INT + 1];
+  block b;
+  transaction tx;
+  bool quit = false;
+  uint64_t bytes_read = 0;
+  int progress_interval = 10;
+
+  while (! quit)
+  {
+    int chunk_size;
+    import_file.read(buffer1, STR_LENGTH_OF_INT);
+    if (!import_file) {
+      std::cout << "\r                   \r";
+      LOG_PRINT_L1("End of import file reached");
+      quit = true;
+      break;
+    }
+    h += NUM_BLOCKS_PER_CHUNK;
+    if (h % progress_interval == 0)
+    {
+      std::cout << "\r                   \r" << "block height: " << h <<
+        std::flush;
+    }
+    bytes_read += STR_LENGTH_OF_INT;
+    buffer1[STR_LENGTH_OF_INT] = '\0';
+    chunk_size = atoi(buffer1);
+    if (chunk_size > BUFFER_SIZE)
+    {
+      std::cout << "\r                   \r";
+      LOG_PRINT_L0("WARNING: chunk_size " << chunk_size << " > BUFFER_SIZE " << BUFFER_SIZE
+          << "  height: " << h);
+      throw std::runtime_error("Aborting: chunk size exceeds buffer size");
+    }
+    if (chunk_size > 100000)
+    {
+      std::cout << "\r                   \r";
+      LOG_PRINT_L0("WARNING: chunk_size " << chunk_size << " > 100000" << "  height: "
+          << h);
+    }
+    else if (chunk_size <= 0) {
+      std::cout << "\r                   \r";
+      LOG_PRINT_L0("ERROR: chunk_size " << chunk_size << " <= 0" << "  height: " << h);
+      throw std::runtime_error("Aborting");
+    }
+    // skip to next expected block size value
+    import_file.seekg(chunk_size, std::ios_base::cur);
+    if (! import_file) {
+      std::cout << "\r                   \r";
+      LOG_PRINT_L0("ERROR: unexpected end of import file: bytes read before error: "
+          << import_file.gcount() << " of chunk_size " << chunk_size);
+      throw std::runtime_error("Aborting");
+    }
+    bytes_read += chunk_size;
+    std::cout << "\r                   \r";
+    LOG_PRINT_L3("Total bytes scanned: " << bytes_read);
+  }
+
+  import_file.close();
+
+  std::cout << ENDL;
+  std::cout << "Done scanning import file" << ENDL;
+  std::cout << "Total bytes scanned: " << bytes_read << ENDL;
+  std::cout << "Height: " << h << ENDL;
+
+  return h;
+}
+
+template <typename FakeCore>
+int import_from_file(FakeCore& simple_core, std::string& import_file_path)
+{
+#if !defined(BLOCKCHAIN_DB)
+  static_assert(std::is_same<fake_core_memory, FakeCore>::value || std::is_same<fake_core_lmdb, FakeCore>::value,
+      "FakeCore constraint error");
+#endif
+#if !defined(BLOCKCHAIN_DB) || (BLOCKCHAIN_DB == DB_LMDB)
+  if (std::is_same<fake_core_lmdb, FakeCore>::value)
+  {
+    // Reset stats, in case we're using newly created db, accumulating stats
+    // from addition of genesis block.
+    // This aligns internal db counts with importer counts.
+    simple_core.m_storage.get_db()->reset_stats();
+  }
+#endif
+  boost::filesystem::path raw_file_path(import_file_path);
+  boost::system::error_code ec;
+  if (!boost::filesystem::exists(raw_file_path, ec))
+  {
+    LOG_PRINT_L0("import file not found: " << raw_file_path);
+    return false;
+  }
+
+  uint64_t source_height = count_blocks(import_file_path);
+  LOG_PRINT_L0("import file blockchain height: " << source_height);
+
+  std::ifstream import_file;
+  import_file.open(import_file_path, std::ios_base::binary | std::ifstream::in);
+
+  uint64_t h = 0;
+  if (import_file.fail())
+  {
+    LOG_PRINT_L0("import_file.open() fail");
+    return false;
+  }
+  char buffer1[STR_LENGTH_OF_INT + 1];
+  char buffer_block[BUFFER_SIZE];
+  block b;
+  transaction tx;
+  int quit = 0;
+  uint64_t bytes_read = 0;
+
+  uint64_t start_height = 1;
+  if (opt_resume)
+    start_height = simple_core.m_storage.get_current_blockchain_height();
+
+  // Note that a new blockchain will start with a height of 1 (block number 0)
+  // due to genesis block being added at initialization.
+
+  // CONFIG
+  // TODO: can expand on this, e.g. with --block-number option
+  uint64_t stop_height = source_height;
+
+  // These are what we'll try to use, and they don't have to be a determination
+  // from source and destination blockchains, but those are the current
+  // defaults.
+  LOG_PRINT_L0("start height: " << start_height << "  stop height: " <<
+      stop_height);
+
+  bool use_batch = false;
+  if (opt_batch)
+  {
+    if (simple_core.support_batch)
+      use_batch = true;
+    else
+      LOG_PRINT_L0("WARNING: batch transactions enabled but unsupported or unnecessary for this database engine - ignoring");
+  }
+
+  if (use_batch)
+    simple_core.batch_start();
+
+  LOG_PRINT_L0("Reading blockchain from import file...");
+  std::cout << ENDL;
+
+  // Within the loop, we skip to start_height before we start adding.
+  // TODO: Not a bottleneck, but we can use what's done in count_blocks() and
+  // only do the chunk size reads, skipping the chunk content reads until we're
+  // at start_height.
+  while (! quit)
+  {
+    int chunk_size;
+    import_file.read(buffer1, STR_LENGTH_OF_INT);
+    if (! import_file) {
+      std::cout << "\r                   \r";
+      LOG_PRINT_L0("End of import file reached");
+      quit = 1;
+      break;
+    }
+    bytes_read += STR_LENGTH_OF_INT;
+    buffer1[STR_LENGTH_OF_INT] = '\0';
+    chunk_size = atoi(buffer1);
+    if (chunk_size > BUFFER_SIZE)
+    {
+      LOG_PRINT_L0("WARNING: chunk_size " << chunk_size << " > BUFFER_SIZE " << BUFFER_SIZE);
+      throw std::runtime_error("Aborting: chunk size exceeds buffer size");
+    }
+    if (chunk_size > 100000)
+    {
+      LOG_PRINT_L0("WARNING: chunk_size " << chunk_size << " > 100000");
+    }
+    else if (chunk_size < 0) {
+      LOG_PRINT_L0("ERROR: chunk_size " << chunk_size << " < 0");
+      return 2;
+    }
+    import_file.read(buffer_block, chunk_size);
+    if (! import_file) {
+      LOG_PRINT_L0("ERROR: unexpected end of import file: bytes read before error: "
+          << import_file.gcount() << " of chunk_size " << chunk_size);
+      return 2;
+    }
+    bytes_read += chunk_size;
+    LOG_PRINT_L3("Total bytes read: " << bytes_read);
+
+    if (h + NUM_BLOCKS_PER_CHUNK < start_height + 1)
+    {
+      h += NUM_BLOCKS_PER_CHUNK;
+      continue;
+    }
+    if (h > stop_height)
+    {
+      LOG_PRINT_L0("Specified height reached - stopping.  height: " << h << "  block: " << h-1);
+      quit = 1;
+      break;
+    }
+
+    try
+    {
+      boost::iostreams::basic_array_source<char> device(buffer_block, chunk_size);
+      boost::iostreams::stream<boost::iostreams::basic_array_source<char>> s(device);
+      boost::archive::binary_iarchive a(s);
+
+      int display_interval = 1000;
+      int progress_interval = 10;
+      for (int chunk_ind = 0; chunk_ind < NUM_BLOCKS_PER_CHUNK; chunk_ind++)
+      {
+        h++;
+        if (h % display_interval == 0)
+        {
+          std::cout << "\r                   \r";
+          LOG_PRINT_L0("loading block height " << h);
+        }
+        else
+        {
+          LOG_PRINT_L3("loading block height " << h);
+        }
+        try {
+          a >> b;
+        }
+        catch (const std::exception& e)
+        {
+          std::cout << "\r                   \r";
+          LOG_PRINT_RED_L0("exception while de-archiving block, height=" << h);
+          quit = 1;
+          break;
+        }
+        LOG_PRINT_L2("block prev_id: " << b.prev_id << ENDL);
+
+        if (h % progress_interval == 0)
+        {
+          std::cout << "\r                   \r" << "block " << h-1
+            << std::flush;
+        }
+
+        std::vector<transaction> txs;
+
+        int num_txs;
+        try
+        {
+          a >> num_txs;
+        }
+        catch (const std::exception& e)
+        {
+          std::cout << "\r                   \r";
+          LOG_PRINT_RED_L0("exception while de-archiving tx-num, height=" << h);
+          quit = 1;
+          break;
+        }
+        for(int tx_num = 1; tx_num <= num_txs; tx_num++)
+        {
+          try {
+                a >> tx;
+          }
+          catch (const std::exception& e)
+          {
+            LOG_PRINT_RED_L0("exception while de-archiving tx, height=" << h <<", tx_num=" << tx_num);
+            quit = 1;
+            break;
+          }
+          // if (tx_num == 1) {
+          //   std::cout << "coinbase transaction" << ENDL;
+          // }
+          // crypto::hash hsh = null_hash;
+          // size_t blob_size = 0;
+          // NOTE: all tx hashes except for coinbase tx are available in the block data
+          // get_transaction_hash(tx, hsh, blob_size);
+          // LOG_PRINT_L0("tx " << tx_num << "  " << hsh << " : " << ENDL);
+          // LOG_PRINT_L0(obj_to_json_str(tx) << ENDL);
+
+          // add blocks with verification.
+          // for Blockchain and blockchain_storage add_new_block().
+          if (opt_verify)
+          {
+            if (tx_num == 1) {
+              continue; // coinbase transaction. no need to insert to tx_pool.
+            }
+            // crypto::hash hsh = null_hash;
+            // size_t blob_size = 0;
+            // get_transaction_hash(tx, hsh, blob_size);
+            tx_verification_context tvc = AUTO_VAL_INIT(tvc);
+            bool r = true;
+            r = simple_core.m_pool.add_tx(tx, tvc, true);
+            if (!r)
+            {
+              LOG_PRINT_RED_L0("failed to add transaction to transaction pool, height=" << h <<", tx_num=" << tx_num);
+              quit = 1;
+              break;
+            }
+          }
+          else
+          {
+            // for add_block() method, without (much) processing.
+            // don't add coinbase transaction to txs.
+            //
+            // because add_block() calls
+            // add_transaction(blk_hash, blk.miner_tx) first, and
+            // then a for loop for the transactions in txs.
+            if (tx_num > 1)
+            {
+              txs.push_back(tx);
+            }
+          }
+        }
+
+        if (opt_verify)
+        {
+          block_verification_context bvc = boost::value_initialized<block_verification_context>();
+          simple_core.m_storage.add_new_block(b, bvc);
+
+          if (bvc.m_verifivation_failed)
+          {
+            LOG_PRINT_L0("Failed to add block to blockchain, verification failed, height = " << h);
+            LOG_PRINT_L0("skipping rest of import file");
+            // ok to commit previously batched data because it failed only in
+            // verification of potential new block with nothing added to batch
+            // yet
+            quit = 1;
+            break;
+          }
+          if (! bvc.m_added_to_main_chain)
+          {
+            LOG_PRINT_L0("Failed to add block to blockchain, height = " << h);
+            LOG_PRINT_L0("skipping rest of import file");
+            // make sure we don't commit partial block data
+            quit = 2;
+            break;
+          }
+        }
+        else
+        {
+          size_t block_size;
+          difficulty_type cumulative_difficulty;
+          uint64_t coins_generated;
+
+          a >> block_size;
+          a >> cumulative_difficulty;
+          a >> coins_generated;
+
+          std::cout << "\r                   \r";
+          LOG_PRINT_L2("block_size: " << block_size);
+          LOG_PRINT_L2("cumulative_difficulty: " << cumulative_difficulty);
+          LOG_PRINT_L2("coins_generated: " << coins_generated);
+
+          try
+          {
+            simple_core.add_block(b, block_size, cumulative_difficulty, coins_generated, txs);
+          }
+          catch (const std::exception& e)
+          {
+            std::cout << "\r                   \r";
+            LOG_PRINT_RED_L0("Error adding block to blockchain: " << e.what());
+            quit = 2; // make sure we don't commit partial block data
+            break;
+          }
+        }
+
+        if (use_batch)
+        {
+          if (h % db_batch_size == 0)
+          {
+            std::cout << "\r                   \r";
+            std::cout << ENDL << "[- batch commit at height " << h << " -]" << ENDL;
+            simple_core.batch_stop();
+            simple_core.batch_start();
+            std::cout << ENDL;
+#if !defined(BLOCKCHAIN_DB) || (BLOCKCHAIN_DB == DB_LMDB)
+            simple_core.m_storage.get_db()->show_stats();
+#endif
+          }
+        }
+      }
+    }
+    catch (const std::exception& e)
+    {
+      std::cout << "\r                   \r";
+      LOG_PRINT_RED_L0("exception while reading from import file, height=" << h);
+      return 2;
+    }
+  } // while
+
+  import_file.close();
+
+  if (use_batch)
+  {
+    if (quit > 1)
+    {
+      // There was an error, so don't commit pending data.
+      // Destructor will abort write txn.
+    }
+    else
+    {
+      simple_core.batch_stop();
+    }
+#if !defined(BLOCKCHAIN_DB) || (BLOCKCHAIN_DB == DB_LMDB)
+    simple_core.m_storage.get_db()->show_stats();
+#endif
+    if (h > 0)
+      LOG_PRINT_L0("Finished at height: " << h << "  block: " << h-1);
+  }
+  std::cout << ENDL;
+  return 0;
+}
+
+int main(int argc, char* argv[])
+{
+  std::string import_filename = BLOCKCHAIN_RAW;
+#if defined(BLOCKCHAIN_DB) && (BLOCKCHAIN_DB == DB_MEMORY)
+  std::string default_db_engine = "memory";
+#else
+  std::string default_db_engine = "lmdb";
+#endif
+
+  uint32_t log_level = LOG_LEVEL_0;
+  std::string dirname;
+  std::string db_engine;
+
+  boost::filesystem::path default_data_path {tools::get_default_data_dir()};
+  boost::filesystem::path default_testnet_data_path {default_data_path / "testnet"};
+
+  po::options_description desc_cmd_only("Command line options");
+  po::options_description desc_cmd_sett("Command line options and settings options");
+  const command_line::arg_descriptor<uint32_t> arg_log_level   =  {"log-level",  "", log_level};
+  const command_line::arg_descriptor<uint64_t> arg_batch_size  =  {"batch-size", "", db_batch_size};
+  const command_line::arg_descriptor<bool>     arg_testnet_on  = {
+    "testnet"
+      , "Run on testnet."
+      , false
+  };
+  const command_line::arg_descriptor<bool>     arg_count_blocks = {
+    "count-blocks"
+      , "Count blocks in import file and exit"
+      , false
+  };
+  const command_line::arg_descriptor<std::string> arg_database = {
+    "database", "available: memory, lmdb"
+      , default_db_engine
+  };
+  const command_line::arg_descriptor<bool> arg_verify =  {"verify",
+    "Verify blocks and transactions during import", true};
+  const command_line::arg_descriptor<bool> arg_batch  =  {"batch",
+    "Batch transactions for faster import", true};
+  const command_line::arg_descriptor<bool> arg_resume =  {"resume",
+    "Resume from current height if output database already exists", true};
+
+  command_line::add_arg(desc_cmd_sett, command_line::arg_data_dir, default_data_path.string());
+  command_line::add_arg(desc_cmd_sett, command_line::arg_testnet_data_dir, default_testnet_data_path.string());
+  command_line::add_arg(desc_cmd_sett, arg_log_level);
+  command_line::add_arg(desc_cmd_sett, arg_batch_size);
+  command_line::add_arg(desc_cmd_sett, arg_testnet_on);
+  command_line::add_arg(desc_cmd_sett, arg_database);
+
+  command_line::add_arg(desc_cmd_only, arg_count_blocks);
+  command_line::add_arg(desc_cmd_only, command_line::arg_help);
+
+  // call add_options() directly for these arguments since
+  // command_line helpers support only boolean switch, not boolean argument
+  desc_cmd_sett.add_options()
+    (arg_verify.name, make_semantic(arg_verify), arg_verify.description)
+    (arg_batch.name,  make_semantic(arg_batch),  arg_batch.description)
+    (arg_resume.name, make_semantic(arg_resume), arg_resume.description)
+    ;
+
+  po::options_description desc_options("Allowed options");
+  desc_options.add(desc_cmd_only).add(desc_cmd_sett);
+
+  po::variables_map vm;
+  bool r = command_line::handle_error_helper(desc_options, [&]()
+  {
+    po::store(po::parse_command_line(argc, argv, desc_options), vm);
+    po::notify(vm);
+    return true;
+  });
+  if (! r)
+    return 1;
+
+  log_level     = command_line::get_arg(vm, arg_log_level);
+  opt_verify    = command_line::get_arg(vm, arg_verify);
+  opt_batch     = command_line::get_arg(vm, arg_batch);
+  opt_resume    = command_line::get_arg(vm, arg_resume);
+  db_batch_size = command_line::get_arg(vm, arg_batch_size);
+
+  if (command_line::get_arg(vm, command_line::arg_help))
+  {
+    std::cout << CRYPTONOTE_NAME << " v" << MONERO_VERSION_FULL << ENDL << ENDL;
+    std::cout << desc_options << std::endl;
+    return 1;
+  }
+
+  if (! opt_batch && ! vm["batch-size"].defaulted())
+  {
+    std::cerr << "Error: batch-size set, but batch option not enabled" << ENDL;
+    exit(1);
+  }
+  if (! db_batch_size)
+  {
+    std::cerr << "Error: batch-size must be > 0" << ENDL;
+    exit(1);
+  }
+
+  std::vector<std::string> db_engines {"memory", "lmdb"};
+
+  opt_testnet = command_line::get_arg(vm, arg_testnet_on);
+  auto data_dir_arg = opt_testnet ? command_line::arg_testnet_data_dir : command_line::arg_data_dir;
+  dirname = command_line::get_arg(vm, data_dir_arg);
+  db_engine = command_line::get_arg(vm, arg_database);
+
+  log_space::get_set_log_detalisation_level(true, log_level);
+  log_space::log_singletone::add_logger(LOGGER_CONSOLE, NULL, NULL);
+  LOG_PRINT_L0("Starting...");
+  LOG_PRINT_L0("Setting log level = " << log_level);
+
+  boost::filesystem::path file_path {dirname};
+  std::string import_file_path;
+
+  import_file_path = (file_path / "export" / import_filename).string();
+
+  if (command_line::has_arg(vm, arg_count_blocks))
+  {
+    count_blocks(import_file_path);
+    exit(0);
+  }
+
+  if (std::find(db_engines.begin(), db_engines.end(), db_engine) == db_engines.end())
+  {
+    std::cerr << "Invalid database engine: " << db_engine << std::endl;
+    exit(1);
+  }
+
+  LOG_PRINT_L0("database: " << db_engine);
+  LOG_PRINT_L0("verify:  " << std::boolalpha << opt_verify << std::noboolalpha);
+  if (opt_batch)
+  {
+    LOG_PRINT_L0("batch:   " << std::boolalpha << opt_batch << std::noboolalpha
+        << "  batch size: " << db_batch_size);
+  }
+  else
+  {
+    LOG_PRINT_L0("batch:   " << std::boolalpha << opt_batch << std::noboolalpha);
+  }
+  LOG_PRINT_L0("resume:  " << std::boolalpha << opt_resume  << std::noboolalpha);
+  LOG_PRINT_L0("testnet: " << std::boolalpha << opt_testnet << std::noboolalpha);
+
+  std::cout << "import file path: " << import_file_path << ENDL;
+  std::cout << "database path:    " << file_path.string() << ENDL;
+
+  try
+  {
+
+  // fake_core needed for verification to work when enabled.
+  //
+  // NOTE: don't need fake_core method of doing things when we're going to call
+  // BlockchainDB add_block() directly and have available the 3 block
+  // properties to do so. Both ways work, but fake core isn't necessary in that
+  // circumstance.
+
+  // for multi_db_runtime:
+#if !defined(BLOCKCHAIN_DB)
+  if (db_engine == "lmdb")
+  {
+    fake_core_lmdb simple_core(dirname, opt_testnet, opt_batch);
+    import_from_file(simple_core, import_file_path);
+  }
+  else if (db_engine == "memory")
+  {
+    fake_core_memory simple_core(dirname, opt_testnet);
+    import_from_file(simple_core, import_file_path);
+  }
+  else
+  {
+    std::cerr << "database engine unrecognized" << ENDL;
+    exit(1);
+  }
+
+  // for multi_db_compile:
+#else
+  if (db_engine != default_db_engine)
+  {
+    std::cerr << "Invalid database engine for compiled version: " << db_engine << std::endl;
+    exit(1);
+  }
+#if BLOCKCHAIN_DB == DB_LMDB
+  fake_core_lmdb simple_core(dirname, opt_testnet, opt_batch);
+#else
+  fake_core_memory simple_core(dirname, opt_testnet);
+#endif
+
+  import_from_file(simple_core, import_file_path);
+#endif
+
+  }
+  catch (const DB_ERROR& e)
+  {
+    std::cout << std::string("Error loading blockchain db: ") + e.what() + " -- shutting down now" << ENDL;
+    exit(1);
+  }
+
+  // destructors called at exit:
+  //
+  // ensure db closed
+  //   - transactions properly checked and handled
+  //   - disk sync if needed
+  //
+  // fake_core object's destructor is called when it goes out of scope. For an
+  // LMDB fake_core, it calls Blockchain::deinit() on its object, which in turn
+  // calls delete on its BlockchainDB derived class' object, which closes its
+  // files.
+}

--- a/src/blockchain_converter/fake_core.h
+++ b/src/blockchain_converter/fake_core.h
@@ -1,0 +1,143 @@
+// Copyright (c) 2014-2015, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <boost/filesystem.hpp>
+#include "cryptonote_core/blockchain.h" // BlockchainDB and LMDB
+#include "cryptonote_core/blockchain_storage.h" // in-memory DB
+
+using namespace cryptonote;
+
+
+#if !defined(BLOCKCHAIN_DB) || BLOCKCHAIN_DB == DB_LMDB
+
+struct fake_core_lmdb
+{
+  Blockchain m_storage;
+  tx_memory_pool m_pool;
+  bool support_batch;
+  bool support_add_block;
+
+  // for multi_db_runtime:
+#if !defined(BLOCKCHAIN_DB)
+  fake_core_lmdb(const boost::filesystem::path &path, const bool use_testnet=false, const bool do_batch=true) : m_pool(&m_storage), m_storage(m_pool)
+  // for multi_db_compile:
+#else
+  fake_core_lmdb(const boost::filesystem::path &path, const bool use_testnet=false, const bool do_batch=true) : m_pool(m_storage), m_storage(m_pool)
+#endif
+  {
+    m_pool.init(path.string());
+    m_storage.init(path.string(), use_testnet);
+    if (do_batch)
+      m_storage.get_db()->set_batch_transactions(do_batch);
+    support_batch = true;
+    support_add_block = true;
+  }
+  ~fake_core_lmdb()
+  {
+    m_storage.deinit();
+  }
+
+  uint64_t add_block(const block& blk
+                            , const size_t& block_size
+                            , const difficulty_type& cumulative_difficulty
+                            , const uint64_t& coins_generated
+                            , const std::vector<transaction>& txs
+                            )
+  {
+    return m_storage.get_db()->add_block(blk, block_size, cumulative_difficulty, coins_generated, txs);
+  }
+
+  void batch_start()
+  {
+    m_storage.get_db()->batch_start();
+  }
+
+  void batch_stop()
+  {
+    m_storage.get_db()->batch_stop();
+  }
+
+};
+#endif
+
+#if !defined(BLOCKCHAIN_DB) || BLOCKCHAIN_DB == DB_MEMORY
+
+struct fake_core_memory
+{
+  blockchain_storage m_storage;
+  tx_memory_pool m_pool;
+  bool support_batch;
+  bool support_add_block;
+
+  // for multi_db_runtime:
+#if !defined(BLOCKCHAIN_DB)
+  fake_core_memory(const boost::filesystem::path &path, const bool use_testnet=false) : m_pool(&m_storage), m_storage(m_pool)
+#else
+  // for multi_db_compile:
+  fake_core_memory(const boost::filesystem::path &path, const bool use_testnet=false) : m_pool(m_storage), m_storage(&m_pool)
+#endif
+  {
+    m_pool.init(path.string());
+    m_storage.init(path.string(), use_testnet);
+    support_batch = false;
+    support_add_block = false;
+  }
+  ~fake_core_memory()
+  {
+    LOG_PRINT_L3("fake_core_memory() destructor called - want to see it ripple down");
+    m_storage.deinit();
+  }
+
+  uint64_t add_block(const block& blk
+                            , const size_t& block_size
+                            , const difficulty_type& cumulative_difficulty
+                            , const uint64_t& coins_generated
+                            , const std::vector<transaction>& txs
+                            )
+  {
+    // TODO:
+    // would need to refactor handle_block_to_main_chain() to have a direct add_block() method like Blockchain class
+    throw std::runtime_error("direct add_block() method not implemented for in-memory db");
+    return 2;
+  }
+
+  void batch_start()
+  {
+    LOG_PRINT_L0("WARNING: [batch_start] opt_batch set, but this database doesn't support/need transactions - ignoring");
+  }
+
+  void batch_stop()
+  {
+    LOG_PRINT_L0("WARNING: [batch_stop] opt_batch set, but this database doesn't support/need transactions - ignoring");
+  }
+
+};
+
+#endif

--- a/src/blockchain_converter/fake_core.h
+++ b/src/blockchain_converter/fake_core.h
@@ -46,14 +46,14 @@ struct fake_core_lmdb
 
   // for multi_db_runtime:
 #if !defined(BLOCKCHAIN_DB)
-  fake_core_lmdb(const boost::filesystem::path &path, const bool use_testnet=false, const bool do_batch=true) : m_pool(&m_storage), m_storage(m_pool)
+  fake_core_lmdb(const boost::filesystem::path &path, const bool use_testnet=false, const bool do_batch=true, const int mdb_flags=0) : m_pool(&m_storage), m_storage(m_pool)
   // for multi_db_compile:
 #else
-  fake_core_lmdb(const boost::filesystem::path &path, const bool use_testnet=false, const bool do_batch=true) : m_pool(m_storage), m_storage(m_pool)
+  fake_core_lmdb(const boost::filesystem::path &path, const bool use_testnet=false, const bool do_batch=true, const int mdb_flags=0) : m_pool(m_storage), m_storage(m_pool)
 #endif
   {
     m_pool.init(path.string());
-    m_storage.init(path.string(), use_testnet);
+    m_storage.init(path.string(), use_testnet, mdb_flags);
     if (do_batch)
       m_storage.get_db()->set_batch_transactions(do_batch);
     support_batch = true;

--- a/src/blockchain_converter/import.h
+++ b/src/blockchain_converter/import.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2014-2015, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+// TODO: bounds checking is done before writing to buffer, but buffer size
+// should be a sensible maximum
+#define BUFFER_SIZE 1000000
+#define NUM_BLOCKS_PER_CHUNK 1
+#define STR_LENGTH_OF_INT 9
+#define STR_FORMAT_OF_INT "%09d"
+#define BLOCKCHAIN_RAW "blockchain.raw"

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -326,7 +326,7 @@ public:
   void show_stats();
 
   // open the db at location <filename>, or create it if there isn't one.
-  virtual void open(const std::string& filename) = 0;
+  virtual void open(const std::string& filename, const int db_flags = 0) = 0;
 
   // make sure implementation has a create function as well
   virtual void create(const std::string& filename) = 0;

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -635,9 +635,8 @@ BlockchainLMDB::BlockchainLMDB(bool batch_transactions)
   m_height = 0;
 }
 
-void BlockchainLMDB::open(const std::string& filename)
+void BlockchainLMDB::open(const std::string& filename, const int mdb_flags)
 {
-  int mdb_flags = 0;
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
 
   if (m_open)

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -637,6 +637,7 @@ BlockchainLMDB::BlockchainLMDB(bool batch_transactions)
 
 void BlockchainLMDB::open(const std::string& filename)
 {
+  int mdb_flags = 0;
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
 
   if (m_open)
@@ -675,7 +676,7 @@ void BlockchainLMDB::open(const std::string& filename)
   size_t mapsize = 1LL << 34;
   if (auto result = mdb_env_set_mapsize(m_env, mapsize))
     throw0(DB_ERROR(std::string("Failed to set max memory map size: ").append(mdb_strerror(result)).c_str()));
-  if (auto result = mdb_env_open(m_env, filename.c_str(), 0, 0644))
+  if (auto result = mdb_env_open(m_env, filename.c_str(), mdb_flags, 0644))
     throw0(DB_ERROR(std::string("Failed to open lmdb environment: ").append(mdb_strerror(result)).c_str()));
 
   // get a read/write MDB_txn

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -114,7 +114,7 @@ public:
   BlockchainLMDB(bool batch_transactions=false);
   ~BlockchainLMDB();
 
-  virtual void open(const std::string& filename);
+  virtual void open(const std::string& filename, const int mdb_flags=0);
 
   virtual void create(const std::string& filename);
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -226,7 +226,7 @@ uint64_t Blockchain::get_current_blockchain_height() const
 //------------------------------------------------------------------
 //FIXME: possibly move this into the constructor, to avoid accidentally
 //       dereferencing a null BlockchainDB pointer
-bool Blockchain::init(const std::string& config_folder, bool testnet)
+bool Blockchain::init(const std::string& config_folder, const bool testnet, const int db_flags)
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
@@ -246,7 +246,7 @@ bool Blockchain::init(const std::string& config_folder, bool testnet)
   const std::string filename = folder.string();
   try
   {
-    m_db->open(filename);
+    m_db->open(filename, db_flags);
   }
   catch (const DB_OPEN_FAILURE& e)
   {

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -145,6 +145,11 @@ namespace cryptonote
     void set_enforce_dns_checkpoints(bool enforce);
     bool update_checkpoints(const std::string& file_path, bool check_dns);
 
+    BlockchainDB* get_db()
+    {
+      return m_db;
+    }
+
   private:
     typedef std::unordered_map<crypto::hash, size_t> blocks_by_id_index;
     typedef std::unordered_map<crypto::hash, transaction_chain_entry> transactions_container;

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -81,7 +81,7 @@ namespace cryptonote
 
     Blockchain(tx_memory_pool& tx_pool);
 
-    bool init(const std::string& config_folder, bool testnet = false);
+    bool init(const std::string& config_folder, const bool testnet = false, const int db_flags = 0);
     bool deinit();
 
     void set_checkpoints(checkpoints&& chk_pts) { m_checkpoints = chk_pts; }


### PR DESCRIPTION
For importing into the LMDB database, compile with `DATABASE=lmdb`
e.g.
`DATABASE=lmdb make release`
This is also the default compile setting on the blockchain branch.

By default, the exporter will use the original in-memory database (blockchain.bin) as its source.
This default is to make migrating to an LMDB database easy, without having to recompile anything.
To change the source, adjust `SOURCE_DB` in `src/blockchain_converter/blockchain_export.h` according to the comments.

# Usage:

See also each utility's "--help" option.

## Export an existing in-memory database

`$ blockchain_export`
This loads the existing blockchain.bin and exports it to `$MONERO_DATA_DIR/export/blockchain.raw`

## Import the exported file

`$ blockchain_import`
This imports blocks from `$MONERO_DATA_DIR/export/blockchain.raw` into the current database.

Defaults: `--batch on`, `--batch size 20000`, `--verify on`
Batch size refers to number of blocks and can be adjusted for performance based on available RAM.
Verification should only be turned off if importing from a trusted blockchain.

```bash
# use default settings to import blockchain.raw into database
$ blockchain_import

# fast import with large batch size, verification off
$ blockchain_import --batch-size 100000 --verify off

# LMDB flags can be set by appending them to the database type:
# flags: nosync, nometasync, writemap, mapasync
$ blockchain_import --database lmdb#nosync
$ blockchain_import --database lmdb#nosync,nometasync
```

## Blockchain converter with batching
`blockchain_converter` has also been updated and includes batching for faster writes. However, on lower RAM systems, this will be slower than using the exporter and importer utilities. The converter needs to keep the blockchain in memory for the duration of the conversion, like the original bitmonerod, thus leaving less memory available to the destination database to operate.

```bash
$ blockchain_converter --batch on --batch-size 20000
```
